### PR TITLE
Fix: Unexpected redirect problem in signup page

### DIFF
--- a/components/layouts/auth/AuthGuard.tsx
+++ b/components/layouts/auth/AuthGuard.tsx
@@ -15,13 +15,9 @@ import { getWebRoute } from '../../../routes/web';
  */
 const AuthGuard = () => {
   const router = useRouter();
-
   const dispatch = useAppDispatch();
-
   const authToken = getUserLoginCookie();
-
   const { mutate: logout } = useUserLogout();
-
   const { isLoading } = useIsAuthenticated(authToken, {
     onSuccess(user) {
       const { id, email, isVerified } = user;


### PR DESCRIPTION
## Overview
#3 
Fixed the `/signup` -> `login` redirect problem.

## Changes
- Remove AuthGuard from signup page
- Check the authenticate status and if the user logged in redirect to home, if not nothing happens.

## Review points
- /components/pages/signup/SignUpPage.tsx

## Assignee Checklist:

<!-- You can tick the checkboxes if not applicable -->

- [x] The base branch is correct (See: [Types of Branches](https://github.com/genesis-tech-tribe/Time-Tracker-frontend/blob/develop/docs/CONTRIBUTING.md#types-of-branches))
- [x] The branch name follows the [Branch Naming Conventions](https://github.com/genesis-tech-tribe/Time-Tracker-frontend/blob/develop/docs/CONTRIBUTING.md#branch-naming-conventions)
- [x] The correct assignees and reviewers have been designated for this PR
- [x] The coding style follows the [Coding Style Guide](https://github.com/genesis-tech-tribe/Time-Tracker-frontend/blob/develop/docs/STYLEGUIDE.md)
- [x] All the related issues are associated with this PR
- [x] All criteria in the associated issues are met (please tick the checkboxes)
- [x] My changes do not generate new warnings or errors (especially in the console)

## Reviewer Checklist:

<!-- You can tick the checkboxes if not applicable -->

- [x] The code follows the generic best practices and our [Coding Style Guide](https://github.com/genesis-tech-tribe/Time-Tracker-frontend/blob/develop/docs/STYLEGUIDE.md)
- [x] Code is well-commented and easy to understand
- [x] UI changes accurately reflect the provided design
